### PR TITLE
Feat#12 프로젝트 질문 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,18 +25,20 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'software.amazon.awssdk:bedrockruntime:2.31.35'
-	implementation 'software.amazon.awssdk:bedrockruntime'
+	implementation 'software.amazon.awssdk:bedrockagentruntime:2.31.35'
+	implementation 'software.amazon.awssdk:s3:2.20.150'
 	implementation 'org.json:json:20240303'
+	implementation 'org.jsoup:jsoup:1.15.3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/intelliview/config/AwsConfig.java
+++ b/src/main/java/com/example/intelliview/config/AwsConfig.java
@@ -6,7 +6,9 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class AwsConfig {
@@ -18,12 +20,30 @@ public class AwsConfig {
     @Value("${AWS_REGION}")
     private String region;
 
+
+    AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
     @Bean
     public BedrockRuntimeClient bedrockRuntimeClient() {
-        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return BedrockRuntimeClient.builder()
             .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
             .region(Region.of(region))
+            .build();
+    }
+
+    @Bean
+    public BedrockAgentRuntimeClient bedrockAgentRuntimeClient() {
+        return BedrockAgentRuntimeClient.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+            .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
             .build();
     }
 }

--- a/src/main/java/com/example/intelliview/config/AwsConfig.java
+++ b/src/main/java/com/example/intelliview/config/AwsConfig.java
@@ -20,11 +20,9 @@ public class AwsConfig {
     @Value("${AWS_REGION}")
     private String region;
 
-
-    AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
     @Bean
     public BedrockRuntimeClient bedrockRuntimeClient() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return BedrockRuntimeClient.builder()
             .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
             .region(Region.of(region))
@@ -33,6 +31,7 @@ public class AwsConfig {
 
     @Bean
     public BedrockAgentRuntimeClient bedrockAgentRuntimeClient() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return BedrockAgentRuntimeClient.builder()
             .region(Region.of(region))
             .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
@@ -41,6 +40,7 @@ public class AwsConfig {
 
     @Bean
     public S3Client s3Client() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
             .region(Region.of(region))
             .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))

--- a/src/main/java/com/example/intelliview/controller/InterviewController.java
+++ b/src/main/java/com/example/intelliview/controller/InterviewController.java
@@ -2,6 +2,8 @@ package com.example.intelliview.controller;
 
 import com.example.intelliview.dto.interview.InterviewInfoDto;
 import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionsResponseDto;
+import com.example.intelliview.repository.InterviewRepository;
+import com.example.intelliview.service.BedrockService;
 import com.example.intelliview.service.InterviewService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class InterviewController {
 
     private final InterviewService interviewService;
+    private final BedrockService bedrockService;
+    private final InterviewRepository interviewRepository;
 
     @PostMapping("/info")
     public ResponseEntity<Long> getInterviewInfo(@RequestBody InterviewInfoDto interviewInfoDto) {
@@ -29,5 +33,11 @@ public class InterviewController {
     public ResponseEntity<QuestionsResponseDto> startInterview(@PathVariable Long id)
         throws IOException {
         return ResponseEntity.ok(interviewService.startInterview(id));
+    }
+
+    @PostMapping("/{interviewId}/project-questions")
+    public ResponseEntity<Void> createProjectQuestions(@PathVariable Long interviewId) throws IOException {
+        bedrockService.createProjectQuestions(interviewRepository.findById(interviewId).orElseThrow());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/intelliview/controller/InterviewController.java
+++ b/src/main/java/com/example/intelliview/controller/InterviewController.java
@@ -5,6 +5,7 @@ import com.example.intelliview.dto.interview.InterviewInfoDto;
 import com.example.intelliview.dto.interview.InterviewQuestionsDto;
 import com.example.intelliview.service.InterviewService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,8 @@ public class InterviewController {
     }
 
     @GetMapping("/{id}/start")
-    public ResponseEntity<InterviewQuestionsDto> startInterview(@PathVariable Long id) throws JsonProcessingException {
+    public ResponseEntity<InterviewQuestionsDto.questionsResponseDto> startInterview(@PathVariable Long id)
+        throws IOException {
         return ResponseEntity.ok(interviewService.startInterview(id));
     }
 }

--- a/src/main/java/com/example/intelliview/controller/InterviewController.java
+++ b/src/main/java/com/example/intelliview/controller/InterviewController.java
@@ -1,12 +1,9 @@
 package com.example.intelliview.controller;
 
-import com.example.intelliview.domain.Question;
 import com.example.intelliview.dto.interview.InterviewInfoDto;
-import com.example.intelliview.dto.interview.InterviewQuestionsDto;
+import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionsResponseDto;
 import com.example.intelliview.service.InterviewService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,7 +26,7 @@ public class InterviewController {
     }
 
     @GetMapping("/{id}/start")
-    public ResponseEntity<InterviewQuestionsDto.questionsResponseDto> startInterview(@PathVariable Long id)
+    public ResponseEntity<QuestionsResponseDto> startInterview(@PathVariable Long id)
         throws IOException {
         return ResponseEntity.ok(interviewService.startInterview(id));
     }

--- a/src/main/java/com/example/intelliview/domain/Interview.java
+++ b/src/main/java/com/example/intelliview/domain/Interview.java
@@ -31,6 +31,8 @@ public class Interview extends BaseTimeEntity{
     @Column(columnDefinition = "text")
     private String qualification;
 
+    private String githubUsername;
+
     @ManyToOne
     @JoinColumn(name = "u_id", nullable = false)
     private Member member;

--- a/src/main/java/com/example/intelliview/domain/Member.java
+++ b/src/main/java/com/example/intelliview/domain/Member.java
@@ -26,6 +26,7 @@ public class Member extends BaseTimeEntity{
     private String password;
     private String salt;
     private String role;
+    private String githubUsername;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category")

--- a/src/main/java/com/example/intelliview/domain/Question.java
+++ b/src/main/java/com/example/intelliview/domain/Question.java
@@ -36,6 +36,9 @@ public class Question extends BaseTimeEntity{
     private QuestionType questionType;
 
     @Builder.Default
+    private Boolean isSolved = false;
+
+    @Builder.Default
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     private List<UserDailyQuestion> userDailyQuestions = new ArrayList<>();
 

--- a/src/main/java/com/example/intelliview/domain/Question.java
+++ b/src/main/java/com/example/intelliview/domain/Question.java
@@ -32,6 +32,9 @@ public class Question extends BaseTimeEntity{
 
     private Integer difficulty;
 
+    @Enumerated(EnumType.STRING)
+    private QuestionType questionType;
+
     @Builder.Default
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     private List<UserDailyQuestion> userDailyQuestions = new ArrayList<>();

--- a/src/main/java/com/example/intelliview/domain/QuestionType.java
+++ b/src/main/java/com/example/intelliview/domain/QuestionType.java
@@ -1,0 +1,6 @@
+package com.example.intelliview.domain;
+
+public enum QuestionType {
+    PROJECT,
+    TECHNICAL
+}

--- a/src/main/java/com/example/intelliview/dto/interview/InterviewInfoDto.java
+++ b/src/main/java/com/example/intelliview/dto/interview/InterviewInfoDto.java
@@ -13,4 +13,5 @@ import lombok.NoArgsConstructor;
 public class InterviewInfoDto {
     private String occupation;
     private String qualification;
+    private String githubUsername;
 }

--- a/src/main/java/com/example/intelliview/dto/interview/InterviewInfoDto.java
+++ b/src/main/java/com/example/intelliview/dto/interview/InterviewInfoDto.java
@@ -13,5 +13,4 @@ import lombok.NoArgsConstructor;
 public class InterviewInfoDto {
     private String occupation;
     private String qualification;
-    private String githubUsername;
 }

--- a/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
+++ b/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
@@ -7,10 +7,22 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class InterviewQuestionsDto {
-    ArrayList<String> questions;
+
+    @Builder
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public class questionsResponseDto{
+        ArrayList<questionDto> questions;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public class questionDto{
+        private String question;
+        private String category;
+    }
 }

--- a/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
+++ b/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
@@ -1,6 +1,6 @@
 package com.example.intelliview.dto.interview;
 
-import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +14,7 @@ public class InterviewQuestionsDto {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class QuestionsResponseDto {
-        ArrayList<QuestionDto> questions;
+        List<QuestionDto> questions;
     }
 
     @Builder

--- a/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
+++ b/src/main/java/com/example/intelliview/dto/interview/InterviewQuestionsDto.java
@@ -13,15 +13,15 @@ public class InterviewQuestionsDto {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    public class questionsResponseDto{
-        ArrayList<questionDto> questions;
+    public static class QuestionsResponseDto {
+        ArrayList<QuestionDto> questions;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    public class questionDto{
+    public static class QuestionDto {
         private String question;
         private String category;
     }

--- a/src/main/java/com/example/intelliview/repository/QuestionRepository.java
+++ b/src/main/java/com/example/intelliview/repository/QuestionRepository.java
@@ -1,8 +1,18 @@
 package com.example.intelliview.repository;
 
 import com.example.intelliview.domain.Question;
+import com.example.intelliview.domain.QuestionType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query(value = "SELECT * FROM question q " +
+        "WHERE q.question_type = 'PROJECT' AND q.is_solved = FALSE " +
+        "ORDER BY RAND() LIMIT 3",
+        nativeQuery = true)
+    List<Question> findRandomUnsolvedProjectQuestions();
 
 }

--- a/src/main/java/com/example/intelliview/repository/QuestionRepository.java
+++ b/src/main/java/com/example/intelliview/repository/QuestionRepository.java
@@ -9,9 +9,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    @Query(value = "SELECT * FROM question q " +
-        "WHERE q.question_type = 'PROJECT' AND q.is_solved = FALSE " +
-        "ORDER BY RAND() LIMIT 3",
+    @Query(value = "SELECT * FROM question " +
+        "WHERE id IN ( " +
+        "    SELECT id FROM question " +
+        "    WHERE question_type = 'PROJECT' AND is_solved = FALSE " +
+        "    ORDER BY RANDOM() " +
+        "    LIMIT 3 " +
+        ")",
         nativeQuery = true)
     List<Question> findRandomUnsolvedProjectQuestions();
 

--- a/src/main/java/com/example/intelliview/service/BedrockService.java
+++ b/src/main/java/com/example/intelliview/service/BedrockService.java
@@ -1,21 +1,33 @@
 package com.example.intelliview.service;
 
 import com.example.intelliview.domain.Interview;
+import com.example.intelliview.domain.Member;
 import com.example.intelliview.domain.Question;
+import com.example.intelliview.domain.QuestionType;
 import com.example.intelliview.dto.interview.GeneratedQuestionDto;
 import com.example.intelliview.repository.QuestionRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient;
+import software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseRetrieveAndGenerateConfiguration;
+import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveAndGenerateConfiguration;
+import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveAndGenerateInput;
+import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveAndGenerateRequest;
+import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveAndGenerateResponse;
+import software.amazon.awssdk.services.bedrockagentruntime.model.RetrieveAndGenerateSessionConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
@@ -25,15 +37,27 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 @Slf4j
 @Transactional
 public class BedrockService{
+
+    @Value("${KNOWLEDGEBASE_ID}")
+    private String knowledgeBaseId;
+
     private final BedrockRuntimeClient bedrockRuntimeClient;
+    private final BedrockAgentRuntimeClient bedrockAgentRuntimeClient;
     private final QuestionRepository questionRepository;
+    private final JSoupService jsoupService;
+
 
     public ArrayList<String> generateInterviewQuestions(Interview interview) throws JsonProcessingException {
+        ArrayList<String> technicalQuestions = createTechnicalQuestions(interview);
+        return technicalQuestions;
+    }
+
+    private ArrayList<String> createTechnicalQuestions(Interview interview) throws JsonProcessingException {
         JSONObject object = new JSONObject();
         String basicQuery = """
             You are an AI assistant tasked with generating technical interview questions for a computer engineering position.
             
-            Your goal is to create 5 relevant and challenging questions tailored to the candidate’s specific occupation and qualifications.
+            Your goal is to create 2 relevant and challenging questions tailored to the candidate’s specific occupation and qualifications.
             
             All content must be written in Korean.
             
@@ -44,17 +68,13 @@ public class BedrockService{
             
             Guidelines:
             
-            1. Generate exactly 5 questions related to different areas of computer engineering.
+            1. Generate exactly 2 questions related to different areas of computer engineering.
             2. Each question must include:
                - question: the question text (in Korean)
                - modelAnswer: a concise and accurate model answer (in Korean)
                - category: has to be one of these 4 specific technical category (BACKEND,FRONTEND,DEVOPS,CS)
                - difficulty: an integer between 1 and 5 (where 5 is the most difficult)
-            3. The difficulty distribution must be:
-               - 1 question with difficulty 2
-               - 2 questions with difficulty 3
-               - 2 questions with difficulty 4
-            4. The candidate’s qualifications should be reflected in the questions.
+            3. The candidate’s qualifications should be reflected in the questions.
             
             Output Constraint:
             
@@ -82,7 +102,7 @@ public class BedrockService{
               }
             ]
             
-            Remember: only return a JSON array of 5 question objects. No explanation, no tags, no planning.
+            Remember: only return a JSON array of 2 question objects. No explanation, no tags, no planning.
             """;
         String query = basicQuery.replace("{{OCCUPATION}}", interview.getOccupation());
         query = query.replace("{{QUALIFICATION}}", interview.getQualification());
@@ -108,7 +128,6 @@ public class BedrockService{
         JsonNode rootNode = objectMapper.readTree(jsonBody);
         String rawText = rootNode.get("content").get(0).get("text").asText();
         String cleanJson = rawText.replaceAll("(?s)```json\\s*|\\s*```", "");
-        System.out.println(cleanJson);
         List<GeneratedQuestionDto> questions = objectMapper.readValue(cleanJson, new TypeReference<>() {});
         ArrayList<String> questionList = new ArrayList<>();
         for (GeneratedQuestionDto generatedQuestion: questions) {
@@ -117,10 +136,111 @@ public class BedrockService{
                 .category(generatedQuestion.getCategory())
                 .difficulty(generatedQuestion.getDifficulty())
                 .modelAnswer(generatedQuestion.getModelAnswer())
+                .questionType(QuestionType.TECHNICAL)
                 .build();
             questionRepository.save(question);
             questionList.add(generatedQuestion.getQuestion());
         }
         return(questionList);
     }
+
+    public ArrayList<String> createProjectQuestions(Interview interview) throws IOException {
+        Member member = interview.getMember();
+        jsoupService.uploadToS3(interview.getGithubUsername(), member.getId());
+        String basicQuery=  """
+            You are an AI assistant tasked with generating technical interview questions for a computer engineering candidate.
+            
+            Your goal is to create 3 relevant and challenging questions tailored to the candidate’s specific occupation and their past projects, which are stored under the following S3 path: "{{S3_PATH}}". 
+            This directory contains multiple subfolders for different repositories; explore them all as needed.
+            
+            All content must be written in Korean.
+            
+            Here is the candidate’s information:
+            
+            - Occupation: {{OCCUPATION}}
+            
+            Guidelines:
+            
+            1. Generate exactly 3 questions based on the candidate's past projects and occupation.
+            2. Each question must include:
+               - question: the question text (in Korean)
+               - modelAnswer: a concise and accurate model answer (in Korean)
+               - category: must be one of these 4 specific technical categories: BACKEND, FRONTEND, DEVOPS, CS
+               - difficulty: an integer between 1 and 5 (where 5 is the most difficult)
+            3. Use the contents of the candidate’s projects located in "{{S3_PATH}}" to derive question context (e.g., technologies used, project structure, design decisions).
+            
+            Output Constraint:
+            
+            - Your entire response **must be a JSON array only**.
+            - **Do NOT include any planning, explanation, tags, or any text outside of the JSON array.**
+            - Format the output as a proper JSON code block using triple backticks and `json`, like this:
+            
+               ```json
+               [ ... your array of questions ... ]
+               ```
+               Example output format:
+               [
+                 {
+                   "question": "DoctorSonju 프로젝트에서 시큐리티는 어떻게 구성했나요?",
+                   "modelAnswer": "JWT 토큰을 사용해서 액세스 토큰과 리프레시 토큰을 레디스로 관리했습니다.",
+                   "category": "BACKEND",
+                   "difficulty": 2
+                 },
+                 {
+                   "question": "CGCG 프로젝트에서 왜 MongoDB를 사용했나요?",
+                   "modelAnswer": "채팅 기능이 있어서 read 연산의 속력을 높이고 싶어서 사용했습니다.",
+                   "category": "DATABASE",
+                   "difficulty": 3
+                 },
+                 {
+                   "question": "CI/CD 파이프라인 구성 시 어떤 도구를 사용했고, 왜 선택했나요?",
+                   "modelAnswer": "GitHub Actions와 Docker를 사용해서 자동 빌드와 배포를 구성했습니다.",
+                   "category": "DEVOPS",
+                   "difficulty": 4
+                 }
+               ]
+               Remember: Only return a JSON array of 3 question objects. No explanation, no planning, no other text.
+            """;
+        String query = basicQuery.replace("{{OCCUPATION}}", interview.getOccupation());
+        query = query.replace("{{S3_PATH}}", "repos/" + member.getId());
+        String response = askAgent(query);
+        String cleanJson = response.replaceAll("(?s)```json\\s*|\\s*```", "");
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<GeneratedQuestionDto> questions = objectMapper.readValue(cleanJson, new TypeReference<>() {});
+        ArrayList<String> questionList = new ArrayList<>();
+        for (GeneratedQuestionDto generatedQuestion: questions) {
+            Question question = Question.builder()
+                .question(generatedQuestion.getQuestion())
+                .category(generatedQuestion.getCategory())
+                .difficulty(generatedQuestion.getDifficulty())
+                .modelAnswer(generatedQuestion.getModelAnswer())
+                .questionType(QuestionType.PROJECT)
+                .build();
+            questionRepository.save(question);
+            questionList.add(generatedQuestion.getQuestion());
+        }
+        return(questionList);
+
+    }
+
+    public String askAgent(String userInput) {
+        RetrieveAndGenerateRequest request = RetrieveAndGenerateRequest.builder()
+            .sessionId(String.valueOf(UUID.randomUUID()))
+            .input(RetrieveAndGenerateInput.builder()
+                .text(userInput)
+                .build())
+            .retrieveAndGenerateConfiguration(RetrieveAndGenerateConfiguration.builder()
+                .type("KNOWLEDGE_BASE")
+                .knowledgeBaseConfiguration(KnowledgeBaseRetrieveAndGenerateConfiguration.builder()
+                    .knowledgeBaseId(knowledgeBaseId)
+                    .build())
+                .build())
+            .sessionConfiguration(RetrieveAndGenerateSessionConfiguration.builder()
+                .build())
+            .build();
+
+        RetrieveAndGenerateResponse response = bedrockAgentRuntimeClient.retrieveAndGenerate(request);
+        return response.output().text();
+    }
+
 }

--- a/src/main/java/com/example/intelliview/service/InterviewService.java
+++ b/src/main/java/com/example/intelliview/service/InterviewService.java
@@ -14,6 +14,7 @@ import com.example.intelliview.repository.QuestionRepository;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,7 +46,7 @@ public class InterviewService {
     public QuestionsResponseDto startInterview(Long id) throws IOException {
         Interview interview = interviewRepository.findById(id).orElseThrow();
         interview.updateStatus(InterviewStatus.IN_PROGRESS);
-        ArrayList<QuestionDto> QuestionDtos = new ArrayList<>();
+        List<QuestionDto> QuestionDtos = new ArrayList<>();
         ArrayList<String> interviewQuestions = bedrockService.generateInterviewQuestions(interview);
         for (String question : interviewQuestions) {
             QuestionDtos.add(QuestionDto.builder()

--- a/src/main/java/com/example/intelliview/service/InterviewService.java
+++ b/src/main/java/com/example/intelliview/service/InterviewService.java
@@ -2,15 +2,12 @@ package com.example.intelliview.service;
 
 import com.example.intelliview.domain.Interview;
 import com.example.intelliview.domain.InterviewStatus;
-import com.example.intelliview.domain.Member;
-import com.example.intelliview.domain.Question;
 import com.example.intelliview.domain.QuestionType;
 import com.example.intelliview.dto.interview.InterviewInfoDto;
-import com.example.intelliview.dto.interview.InterviewQuestionsDto;
-import com.example.intelliview.dto.interview.InterviewQuestionsDto.questionDto;
+import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionsResponseDto;
+import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionDto;
 import com.example.intelliview.repository.InterviewRepository;
 import com.example.intelliview.repository.MemberRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,26 +37,26 @@ public class InterviewService {
         return interview.getId();
     }
 
-    public InterviewQuestionsDto.questionsResponseDto startInterview(Long id) throws IOException {
+    public QuestionsResponseDto startInterview(Long id) throws IOException {
         Interview interview = interviewRepository.findById(id).orElseThrow();
         interview.updateStatus(InterviewStatus.IN_PROGRESS);
-        ArrayList<InterviewQuestionsDto.questionDto> questionDtos = new ArrayList<>();
+        ArrayList<QuestionDto> QuestionDtos = new ArrayList<>();
         ArrayList<String> projectQuestions = bedrockService.createProjectQuestions(interview);
         for (String question : projectQuestions) {
-            questionDtos.add(questionDto.builder()
+            QuestionDtos.add(QuestionDto.builder()
                 .category(String.valueOf(QuestionType.PROJECT))
                 .question(question)
                 .build());
         }
         ArrayList<String> interviewQuestions = bedrockService.generateInterviewQuestions(interview);
         for (String question : interviewQuestions) {
-            questionDtos.add(questionDto.builder()
+            QuestionDtos.add(QuestionDto.builder()
                 .category(String.valueOf(QuestionType.TECHNICAL))
                 .question(question)
                 .build());
         }
-        return InterviewQuestionsDto.questionsResponseDto.builder()
-            .questions(questionDtos)
+        return QuestionsResponseDto.builder()
+            .questions(QuestionDtos)
             .build();
     }
 }

--- a/src/main/java/com/example/intelliview/service/InterviewService.java
+++ b/src/main/java/com/example/intelliview/service/InterviewService.java
@@ -2,12 +2,15 @@ package com.example.intelliview.service;
 
 import com.example.intelliview.domain.Interview;
 import com.example.intelliview.domain.InterviewStatus;
+import com.example.intelliview.domain.Member;
+import com.example.intelliview.domain.Question;
 import com.example.intelliview.domain.QuestionType;
 import com.example.intelliview.dto.interview.InterviewInfoDto;
 import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionsResponseDto;
 import com.example.intelliview.dto.interview.InterviewQuestionsDto.QuestionDto;
 import com.example.intelliview.repository.InterviewRepository;
 import com.example.intelliview.repository.MemberRepository;
+import com.example.intelliview.repository.QuestionRepository;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -24,14 +27,16 @@ public class InterviewService {
     private final InterviewRepository interviewRepository;
     private final BedrockService bedrockService;
     private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
 
     public Long getInterviewInfo(InterviewInfoDto interviewInfoDto) {
+        Member member = memberRepository.findById(1L).orElseThrow();
         Interview interview = Interview.builder()
             .status(InterviewStatus.SCHEDULED)
             .occupation(interviewInfoDto.getOccupation())
-            .githubUsername(interviewInfoDto.getGithubUsername())
+            .githubUsername(member.getUsername())
             .qualification(interviewInfoDto.getQualification())
-            .member((memberRepository.findById(1L).orElseThrow()))
+            .member(member)
             .build();
         interviewRepository.save(interview);
         return interview.getId();
@@ -41,18 +46,17 @@ public class InterviewService {
         Interview interview = interviewRepository.findById(id).orElseThrow();
         interview.updateStatus(InterviewStatus.IN_PROGRESS);
         ArrayList<QuestionDto> QuestionDtos = new ArrayList<>();
-        ArrayList<String> projectQuestions = bedrockService.createProjectQuestions(interview);
-        for (String question : projectQuestions) {
-            QuestionDtos.add(QuestionDto.builder()
-                .category(String.valueOf(QuestionType.PROJECT))
-                .question(question)
-                .build());
-        }
         ArrayList<String> interviewQuestions = bedrockService.generateInterviewQuestions(interview);
         for (String question : interviewQuestions) {
             QuestionDtos.add(QuestionDto.builder()
                 .category(String.valueOf(QuestionType.TECHNICAL))
                 .question(question)
+                .build());
+        }
+        for (Question question : questionRepository.findRandomUnsolvedProjectQuestions()) {
+            QuestionDtos.add(QuestionDto.builder()
+                .category(String.valueOf(QuestionType.PROJECT))
+                .question(question.getQuestion())
                 .build());
         }
         return QuestionsResponseDto.builder()

--- a/src/main/java/com/example/intelliview/service/JSoupService.java
+++ b/src/main/java/com/example/intelliview/service/JSoupService.java
@@ -3,6 +3,7 @@ package com.example.intelliview.service;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -32,8 +33,8 @@ public class JSoupService {
 
     private final S3Client s3Client;
 
-    public ArrayList<String> getPinnedRepository(String username) throws IOException {
-        ArrayList<String> pinnedRepository = new ArrayList<>();
+    public List<String> getPinnedRepository(String username) throws IOException {
+        List<String> pinnedRepository = new ArrayList<>();
         String url = "https://github.com/" + username;
         Document doc = Jsoup.parse(String.valueOf(Jsoup.connect(url).get()));
         Elements pinnedItems = doc.select("ol.js-pinned-items-reorder-list > li");
@@ -48,7 +49,7 @@ public class JSoupService {
     }
 
     public void uploadToS3(String username, Long memberId) throws IOException {
-        ArrayList<String> repositoryList = getPinnedRepository(username);
+        List<String> repositoryList = getPinnedRepository(username);
         for (String repository : repositoryList) {
             // Github ZIP 다운로드 링크 가져오기
             String zipUrl = getRepositoryZipUrl(repository);

--- a/src/main/java/com/example/intelliview/service/JSoupService.java
+++ b/src/main/java/com/example/intelliview/service/JSoupService.java
@@ -97,7 +97,6 @@ public class JSoupService {
 
     public String getRepositoryZipUrl(String url) throws IOException {
         Document doc = Jsoup.connect(url).get();
-
         Element downloadLink = doc.selectFirst("a.prc-ActionList-ActionListContent-sg9-x.prc-Link-Link-85e08");
         if (downloadLink != null) {
             String href = downloadLink.attr("href");

--- a/src/main/java/com/example/intelliview/service/JSoupService.java
+++ b/src/main/java/com/example/intelliview/service/JSoupService.java
@@ -1,0 +1,109 @@
+package com.example.intelliview.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.io.*;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class JSoupService {
+
+    @Value("${S3_BUCKET_NAME}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    public ArrayList<String> getPinnedRepository(String username) throws IOException {
+        ArrayList<String> pinnedRepository = new ArrayList<>();
+        String url = "https://github.com/" + username;
+        Document doc = Jsoup.parse(String.valueOf(Jsoup.connect(url).get()));
+        Elements pinnedItems = doc.select("ol.js-pinned-items-reorder-list > li");
+        for (Element item : pinnedItems) {
+            Element link = item.selectFirst("a[href]");
+            if (link != null) {
+                String href = link.attr("href");
+                pinnedRepository.add("https://github.com" + href);
+            }
+        }
+        return pinnedRepository;
+    }
+
+    public void uploadToS3(String username, Long memberId) throws IOException {
+        ArrayList<String> repositoryList = getPinnedRepository(username);
+        for (String repository : repositoryList) {
+            // Github ZIP 다운로드 링크 가져오기
+            String zipUrl = getRepositoryZipUrl(repository);
+            String repositoryName = repository.replaceFirst("https://github.com/", "");
+            URI uri = URI.create(zipUrl);
+            URL url = uri.toURL();
+
+            // ZIP 다운로드
+            Path zipPath = Files.createTempFile("repo-", ".zip");
+            try (InputStream in = url.openStream()) {
+                Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            // 압축 풀기
+            Path unzipDir = Files.createTempDirectory("unzipped-repo");
+            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toFile()))) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    Path newFilePath = unzipDir.resolve(entry.getName());
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(newFilePath);
+                    } else {
+                        Files.createDirectories(newFilePath.getParent());
+                        Files.copy(zis, newFilePath, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                }
+            }
+
+            //S3 업로드
+            Files.walk(unzipDir)
+                .filter(Files::isRegularFile)
+                .forEach(path -> {
+                    String key = unzipDir.relativize(path).toString().replace("\\", "/"); // S3 key
+                    s3Client.putObject(PutObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key("repos/" + memberId + "/" + repositoryName + "/" + key)
+                            .build(),
+                        RequestBody.fromFile(path));
+                });
+
+            Files.deleteIfExists(zipPath);
+        }
+
+
+    }
+
+    public String getRepositoryZipUrl(String url) throws IOException {
+        Document doc = Jsoup.connect(url).get();
+
+        Element downloadLink = doc.selectFirst("a.prc-ActionList-ActionListContent-sg9-x.prc-Link-Link-85e08");
+        if (downloadLink != null) {
+            String href = downloadLink.attr("href");
+            return "https://github.com" + href;
+        } else {
+            throw new IOException("Download ZIP 링크를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/intelliview/service/JSoupService.java
+++ b/src/main/java/com/example/intelliview/service/JSoupService.java
@@ -99,7 +99,6 @@ public class JSoupService {
         Document doc = Jsoup.connect(url).get();
         Element branchElement = doc.selectFirst("span[class*=prc-Text-Text-]");
         String defaultBranch = branchElement != null ? branchElement.text().trim() : "main";
-        log.info(url + "/archive/refs/heads/" + defaultBranch + ".zip");
         return url + "/archive/refs/heads/" + defaultBranch + ".zip";
     }
 }

--- a/src/main/java/com/example/intelliview/service/JSoupService.java
+++ b/src/main/java/com/example/intelliview/service/JSoupService.java
@@ -97,12 +97,9 @@ public class JSoupService {
 
     public String getRepositoryZipUrl(String url) throws IOException {
         Document doc = Jsoup.connect(url).get();
-        Element downloadLink = doc.selectFirst("a.prc-ActionList-ActionListContent-sg9-x.prc-Link-Link-85e08");
-        if (downloadLink != null) {
-            String href = downloadLink.attr("href");
-            return "https://github.com" + href;
-        } else {
-            throw new IOException("Download ZIP 링크를 찾을 수 없습니다.");
-        }
+        Element branchElement = doc.selectFirst("span[class*=prc-Text-Text-]");
+        String defaultBranch = branchElement != null ? branchElement.text().trim() : "main";
+        log.info(url + "/archive/refs/heads/" + defaultBranch + ".zip");
+        return url + "/archive/refs/heads/" + defaultBranch + ".zip";
     }
 }

--- a/src/test/java/com/example/intelliview/service/JSoupServiceTest.java
+++ b/src/test/java/com/example/intelliview/service/JSoupServiceTest.java
@@ -1,0 +1,30 @@
+package com.example.intelliview.service;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = JSoupService.class)
+@WebAppConfiguration
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class JSoupServiceTest {
+
+    @Autowired
+    private JSoupService jSoupService;
+
+    @Test
+    void getPinnedRepositoryTest() throws IOException {
+        String username = "minahkim03";
+        System.out.println(jSoupService.getPinnedRepository(username));
+    }
+
+
+}


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 


### 🍀 기대 결과
- "/api/v1/interview/{interviewId}/project-questions"로 POST 요청 보낼 시 프로젝트 질문 생성 가능
- JSoup으로 깃허브 pinned repository의 ZIP 파일 다운로드 링크 추출 -> 다운로드 -> S3 업로드 -> Knowledge Base Agent를 호출해 질문 생성
- 인터뷰 시작 API를 호출하면 랜덤 프로젝트 질문 3개와 즉석에서 새로운 기술 질문 2개를 생성해서 제공


### 🍀 전달사항
- 서버 하나 더 띄우면 인프라 구성이 복잡해질 것 같아서 JSoup 써서 크롤링 했습니다
- 한번에 프로젝트 질문을 5개씩 만들라고 하니까 다음 요청까지 뜸을 좀 많이 들여야되더라고요... 참고하시길 바랍니당
- 생각보다 Knowledge Base 에이전트가 많이 멍청해요😭😭 PR 검토하시면서 지식 기반이랑 에이전트 설정 개선할 점 있는지도 봐주시면 감사하겠습니다.. 지금 프롬프트가 진짜 최선의 결관데 혹시나 더 좋은 답변을 도출할 수 있는 프롬프트 발견하시면 그것도 알려주세요!


### 🍀 스크린샷
<img width="881" alt="스크린샷 2025-06-01 오후 9 58 43" src="https://github.com/user-attachments/assets/cee581cf-e82a-429a-954b-7237020b5567" />


### 🍀 Issue Number
close : #12 