### PR TITLE
Feat: 아카이브 일별, 월별 기능 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'software.amazon.awssdk:bedrockruntime:2.31.35'
@@ -36,7 +36,7 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/intelliview/controller/ArchiveController.java
+++ b/src/main/java/com/example/intelliview/controller/ArchiveController.java
@@ -56,6 +56,15 @@ public class ArchiveController {
             @PathVariable int month,
             @PathVariable int day
     ) {
+        if (memberRepository.findById(1L).isEmpty()) {
+            member = Member.builder()
+                    .id(1L)
+                    .email("test@gmail.com")
+                    .username("test")
+                    .build();
+        }else{
+            member = memberRepository.findById(1L).get();
+        }
         DayArchiveDto response = archiveService.getDayArchive(member, year, month, day);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/intelliview/controller/ArchiveController.java
+++ b/src/main/java/com/example/intelliview/controller/ArchiveController.java
@@ -1,0 +1,63 @@
+package com.example.intelliview.controller;
+
+import com.example.intelliview.domain.Member;
+import com.example.intelliview.domain.Question;
+import com.example.intelliview.domain.UserDailyQuestion;
+import com.example.intelliview.dto.CategoryRequest;
+import com.example.intelliview.dto.DailyAnswerRequest;
+import com.example.intelliview.dto.DailyQuestionResponse;
+import com.example.intelliview.dto.FeedbackResponse;
+import com.example.intelliview.dto.archive.DayArchiveDto;
+import com.example.intelliview.repository.InterviewRepository;
+import com.example.intelliview.repository.MemberRepository;
+import com.example.intelliview.service.ArchiveService;
+import com.example.intelliview.service.DailyQuestionService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/archive")
+public class ArchiveController {
+
+    private final ArchiveService archiveService;
+    private final InterviewRepository interviewRepository;
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/{year}/{month}")
+    public ResponseEntity<List<DayArchiveDto>> getMonthArchive(@AuthenticationPrincipal Member member, @PathVariable int year, @PathVariable int month) {
+        if (memberRepository.findById(1L).isEmpty()) {
+            member = Member.builder()
+                    .id(1L)
+                    .email("test@gmail.com")
+                    .username("test")
+                    .build();
+        }else{
+            member = memberRepository.findById(1L).get();
+        }
+
+        System.out.println("👉 [Get] 요청자: " + member.getUsername());
+
+        List<DayArchiveDto> response = archiveService.getMonthArchive(member, year, month);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{year}/{month}/{day}")
+    public ResponseEntity<DayArchiveDto> getDayArchive(
+            @AuthenticationPrincipal Member member,
+            @PathVariable int year,
+            @PathVariable int month,
+            @PathVariable int day
+    ) {
+        DayArchiveDto response = archiveService.getDayArchive(member, year, month, day);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/intelliview/domain/InterviewAnswer.java
+++ b/src/main/java/com/example/intelliview/domain/InterviewAnswer.java
@@ -1,14 +1,18 @@
 package com.example.intelliview.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Getter
 @Table(name = "interview_answer")
 public class InterviewAnswer extends BaseTimeEntity{
 

--- a/src/main/java/com/example/intelliview/dto/archive/DayArchiveDto.java
+++ b/src/main/java/com/example/intelliview/dto/archive/DayArchiveDto.java
@@ -1,0 +1,16 @@
+package com.example.intelliview.dto.archive;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DayArchiveDto {
+    private LocalDate date;
+    private UserDailyQuestionArchiveDto dailyQuestion;
+    private List<InterviewAnswerArchiveDto> interviews;
+}

--- a/src/main/java/com/example/intelliview/dto/archive/InterviewAnswerArchiveDto.java
+++ b/src/main/java/com/example/intelliview/dto/archive/InterviewAnswerArchiveDto.java
@@ -1,0 +1,32 @@
+package com.example.intelliview.dto.archive;
+import com.example.intelliview.domain.InterviewAnswer;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewAnswerArchiveDto {
+    private Long id;
+    private String answer;
+    private Integer score;
+    private String feedback;
+    private LocalDateTime createdAt;
+    private QuestionSummaryDto question;
+    private InterviewSummaryDto interview;
+
+    public static InterviewAnswerArchiveDto from(InterviewAnswer entity) {
+        return InterviewAnswerArchiveDto.builder()
+                .id(entity.getId())
+                .answer(entity.getAnswer())
+                .score(entity.getScore())
+                .feedback(entity.getFeedback())
+                .createdAt(entity.getCreatedAt())
+                .question(QuestionSummaryDto.from(entity.getQuestion()))
+                // .interview(InterviewSummaryDto.from(entity.getInterview()))
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/intelliview/dto/archive/InterviewSummaryDto.java
+++ b/src/main/java/com/example/intelliview/dto/archive/InterviewSummaryDto.java
@@ -1,0 +1,12 @@
+package com.example.intelliview.dto.archive;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewSummaryDto {
+    private Long id;
+    private String title;
+}

--- a/src/main/java/com/example/intelliview/dto/archive/QuestionSummaryDto.java
+++ b/src/main/java/com/example/intelliview/dto/archive/QuestionSummaryDto.java
@@ -1,0 +1,26 @@
+package com.example.intelliview.dto.archive;
+
+import com.example.intelliview.domain.Question;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionSummaryDto {
+    private Long id;
+    private String question;
+    private String modelAnswer;
+    private String category;
+    private Integer difficulty;
+
+    public static QuestionSummaryDto from(Question entity) {
+        return QuestionSummaryDto.builder()
+                .id(entity.getId())
+                .question(entity.getQuestion())
+                .modelAnswer(entity.getModelAnswer())
+                .category(entity.getCategory().name())
+                .difficulty(entity.getDifficulty())
+                .build();
+    }
+}

--- a/src/main/java/com/example/intelliview/dto/archive/UserDailyQuestionArchiveDto.java
+++ b/src/main/java/com/example/intelliview/dto/archive/UserDailyQuestionArchiveDto.java
@@ -1,0 +1,28 @@
+package com.example.intelliview.dto.archive;
+
+import com.example.intelliview.domain.UserDailyQuestion;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDailyQuestionArchiveDto {
+    private Long id;
+    private String answer;
+    private Integer attemptCount;
+    private LocalDateTime createdAt;
+    private QuestionSummaryDto question;
+
+    public static UserDailyQuestionArchiveDto from(UserDailyQuestion entity) {
+        return UserDailyQuestionArchiveDto.builder()
+                .id(entity.getId())
+                .answer(entity.getAnswer())
+                .attemptCount(entity.getAttemptCount())
+                .createdAt(entity.getCreatedAt())
+                .question(QuestionSummaryDto.from(entity.getQuestion()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/intelliview/repository/UserDailyQuestionRepository.java
+++ b/src/main/java/com/example/intelliview/repository/UserDailyQuestionRepository.java
@@ -1,5 +1,7 @@
 package com.example.intelliview.repository;
 
+import com.example.intelliview.domain.Member;
+import com.example.intelliview.domain.Question;
 import com.example.intelliview.domain.UserDailyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +20,6 @@ public interface UserDailyQuestionRepository extends JpaRepository<UserDailyQues
 
     @Query("SELECT udq FROM UserDailyQuestion udq WHERE udq.member.id = :userId AND udq.question.id = :questionId ORDER BY udq.createdAt DESC")
     List<UserDailyQuestion> findByMemberIdAndQuestionIdOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("questionId") Long questionId);
+
+    List<UserDailyQuestion> findAllByMemberAndCreatedAtBetweenAndAnswerIsNotNull(Member member, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/intelliview/service/ArchiveService.java
+++ b/src/main/java/com/example/intelliview/service/ArchiveService.java
@@ -1,0 +1,101 @@
+package com.example.intelliview.service;
+
+import com.example.intelliview.domain.InterviewAnswer;
+import com.example.intelliview.domain.Member;
+import com.example.intelliview.domain.Question;
+import com.example.intelliview.domain.UserDailyQuestion;
+import com.example.intelliview.dto.archive.DayArchiveDto;
+import com.example.intelliview.dto.archive.InterviewAnswerArchiveDto;
+import com.example.intelliview.dto.archive.UserDailyQuestionArchiveDto;
+import com.example.intelliview.repository.DailyQuestionRepository;
+import com.example.intelliview.repository.MemberRepository;
+import com.example.intelliview.repository.UserDailyQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ArchiveService {
+
+    private final UserDailyQuestionRepository userDailyQuestionRepository;
+
+    public List<DayArchiveDto> getMonthArchive(Member member, int year, int month) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        List<UserDailyQuestion> dailyQuestions = userDailyQuestionRepository
+                .findAllByMemberAndCreatedAtBetweenAndAnswerIsNotNull(
+                        member, start.atStartOfDay(), end.atTime(LocalTime.MAX));
+
+        //TODO: 인터뷰 피드백은 추후 개발. 우선은 빈 리스트 할당.
+//        List<InterviewAnswer> interviewAnswers = interviewAnswerRepository
+//                .findAllByMemberAndCreatedAtBetween(
+//                        member, start.atStartOfDay(), end.atTime(LocalTime.MAX));
+        List<InterviewAnswer> interviewAnswers = new ArrayList<>();
+
+        Map<LocalDate, UserDailyQuestion> dailyMap = dailyQuestions.stream()
+                .collect(Collectors.toMap(
+                        dq -> dq.getCreatedAt().toLocalDate(),
+                        dq -> dq,
+                        (oldVal, newVal) -> newVal
+                ));
+
+        Map<LocalDate, List<InterviewAnswer>> interviewMap = interviewAnswers.stream()
+                .collect(Collectors.groupingBy(ia -> ia.getCreatedAt().toLocalDate()));
+
+        List<DayArchiveDto> result = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            UserDailyQuestion dq = dailyMap.get(date);
+            List<InterviewAnswer> interviews = interviewMap.getOrDefault(date, List.of());
+
+            result.add(DayArchiveDto.builder()
+                    .date(date)
+                    .dailyQuestion(dq != null ? UserDailyQuestionArchiveDto.from(dq) : null)
+                    .interviews(interviews.stream()
+                            .map(InterviewAnswerArchiveDto::from)
+                            .collect(Collectors.toList()))
+                    .build());
+        }
+
+        return result;
+    }
+
+    public DayArchiveDto getDayArchive(Member member, int year, int month, int day) {
+        LocalDate date = LocalDate.of(year, month, day);
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(LocalTime.MAX);
+
+        List<UserDailyQuestion> dailyQuestions = userDailyQuestionRepository
+                .findAllByMemberAndCreatedAtBetweenAndAnswerIsNotNull(member, start, end);
+
+        //TODO: 인터뷰 피드백은 추후 개발. 우선은 빈 리스트 할당.
+//        List<InterviewAnswer> interviewAnswers = interviewAnswerRepository
+//                .findAllByMemberAndCreatedAtBetween(member, start, end);
+        List<InterviewAnswer> interviewAnswers = new ArrayList<>();
+
+        UserDailyQuestionArchiveDto dailyQuestionDto = dailyQuestions.isEmpty()
+                ? null
+                : UserDailyQuestionArchiveDto.from(dailyQuestions.get(0)); // 혹시 여러 개면 첫 번째만
+
+        List<InterviewAnswerArchiveDto> interviewDtos = interviewAnswers.stream()
+                .map(InterviewAnswerArchiveDto::from)
+                .toList();
+
+        return DayArchiveDto.builder()
+                .date(date)
+                .dailyQuestion(dailyQuestionDto)
+                .interviews(interviewDtos)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/intelliview/service/ArchiveService.java
+++ b/src/main/java/com/example/intelliview/service/ArchiveService.java
@@ -85,7 +85,7 @@ public class ArchiveService {
 
         UserDailyQuestionArchiveDto dailyQuestionDto = dailyQuestions.isEmpty()
                 ? null
-                : UserDailyQuestionArchiveDto.from(dailyQuestions.get(0)); // 혹시 여러 개면 첫 번째만
+                : UserDailyQuestionArchiveDto.from(dailyQuestions.getFirst());
 
         List<InterviewAnswerArchiveDto> interviewDtos = interviewAnswers.stream()
                 .map(InterviewAnswerArchiveDto::from)


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 


### 🍀 기대 결과
- 아카이브에서 사용할 월별, 일별 매일질문과 면접 답변을 조회하는 기능입니다.


### 🍀 전달사항
- InterviewAnswer를 조회하도록 했습니다.(혹시 잘못 이해한거라면 말씀주시면 수정하겠습니다.)
- InterviewAnswer에 Getter 추가했습니다.
- InterviewAnswer아직 없어서 현재는 빈값이 들어가고 가져오는 코드는 주석처리되었습니다.


### 🍀 스크린샷

월별조회
<img width="883" alt="image" src="https://github.com/user-attachments/assets/964a0e9b-bb69-4a58-963f-d8926ca93807" />


일별조회
<img width="881" alt="image" src="https://github.com/user-attachments/assets/7e4ebcd1-f2f6-4c81-a723-9e053ac48b4c" />


### 🍀 Issue Number
close : #14 
