### PR TITLE
Fix. Nova Lite 지원 확장자 mp4에서 webm으로 변경

### DIFF
--- a/src/main/java/com/example/intelliview/service/BedrockService.java
+++ b/src/main/java/com/example/intelliview/service/BedrockService.java
@@ -179,7 +179,7 @@ public class BedrockService{
             JSONArray contentArray = new JSONArray();
             contentArray.put(new JSONObject()
                     .put("video", new JSONObject()
-                            .put("format", "mp4")
+                            .put("format", "webm")
                             .put("source", new JSONObject()
                                     .put("s3Location", new JSONObject()
                                             .put("uri", s3Uri)


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : Nova Lite 지원 확장자 mp4에서 webm으로 변경
- [ ] 기타 : 


### 🍀 기대 결과
-webm 파일 프론트에서 받을 수 있음


### 🍀 전달사항
-


### 🍀 스크린샷


### 🍀 Issue Number
close : #
